### PR TITLE
Fix ECS task definition to use environment-specific Docker image tag

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -105,7 +105,7 @@ resource "aws_ecs_task_definition" "app" {
   container_definitions = jsonencode([
     {
       name                   = "sky-high-booker-container"
-      image                  = "${aws_ecr_repository.sky_high_booker.repository_url}:latest"
+      image                  = "${aws_ecr_repository.sky_high_booker.repository_url}:${var.environment}"
       essential              = true
       readonlyRootFilesystem = false
 


### PR DESCRIPTION
- Changed from :latest to :${var.environment}
- Matches CD workflow that pushes images with dev/prod tags
- Fixes CannotPullContainerError for environment-specific deployments