### PR TITLE
fix: export apiGatewayUrl from aws-config and use local.full_domain_n…

### DIFF
--- a/src/lib/aws-config.ts
+++ b/src/lib/aws-config.ts
@@ -58,4 +58,7 @@ export const configureAWS = () => {
   }
 }
 
+// Export API Gateway URL for direct API calls
+export const apiGatewayUrl = import.meta.env.VITE_AWS_API_GATEWAY_URL || 'VITE_AWS_API_GATEWAY_URL_PLACEHOLDER'
+
 export { amplifyConfig }


### PR DESCRIPTION
…ame in Lambda

- Add apiGatewayUrl export to aws-config.ts for chatbot Lambda proxy
- Fix Lambda chatbot SITE_URL to use local.full_domain_name instead of var.domain_name
- Fixes build error: apiGatewayUrl not exported
- Fixes terraform validate error: undeclared input variable domain_name